### PR TITLE
[bug fix] 简体中文文档404

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 FastGateway provides basic management services, including simple login authorization and real-time configuration management, thereby enabling the management of dynamic routing.
 
 -----
-Document Language: [English](README.md) | [简体中文](README.zh-cn.md)
+Document Language: [English](README.md) | [简体中文](README-zh-cn.md)
 
 ## Supported Features
 


### PR DESCRIPTION
`简体中文`文档会404，区别是`.zh`和`-zh`，如下图：

![NQ99I EZF_@SXXI}Q9U}32B](https://github.com/239573049/FastGateway/assets/17940898/83f61b6c-afda-4a81-8bb7-ab96e501197c)
