### PR TITLE
[feat] 优化 HTTPS 相关逻辑，调整页面的提示词和布局

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -3,7 +3,7 @@
 FastGateway提供了基本的管理服务，提供简单的登录授权，和实时配置管理，从而实现动态路由的管理。
 
 -----
-文档语言: [English](README.md) | [简体中文](README.zh-cn.md)
+文档语言: [English](README.md) | [简体中文](README-zh-cn.md)
 
 ## 支持功能
 

--- a/web/src/pages/http-proxy/features/CreateHttpProxy.tsx
+++ b/web/src/pages/http-proxy/features/CreateHttpProxy.tsx
@@ -97,14 +97,29 @@ export default function CreateHttpProxy({
                                         }}
                                     ></Input>
                                 </Col>
-                                <Col span={4}>
+                                <Col span={2}>
                                     <Checkbox
                                         field="isHttps"
                                         onChange={(v: any) => {
                                             values.isHttps = v;
                                             formApi.setValues(values);
                                         }}
-                                        label="SSL"
+                                        label="启用SSL"
+                                        style={{
+                                            marginTop: '10px',
+                                            marginLeft: '10px',
+                                        }}
+                                    ></Checkbox>
+                                </Col>
+                                <Col span={2}>
+                                    <Checkbox
+                                        field="redirectHttps"
+                                        label="强制跳转HTTPS"
+                                        initValue={false}
+                                        onChange={(v: any) => {
+                                            values.redirectHttps = v;
+                                            formApi.setValues(values);
+                                        }}
                                         style={{
                                             marginTop: '10px',
                                             marginLeft: '10px',
@@ -153,23 +168,6 @@ export default function CreateHttpProxy({
                                             formApi.setValues(values);
                                         }}
                                         label={"服务状态：" + (values.enable ? '启用' : '停用')}
-                                        style={{
-                                            marginTop: '5px',
-                                            marginLeft: '10px',
-                                        }}
-                                    ></Checkbox>
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col span={12}>
-                                    <Checkbox
-                                        field="redirectHttps"
-                                        label="启用HTTPS重定向"
-                                        initValue={false}
-                                        onChange={(v: any) => {
-                                            values.redirectHttps = v;
-                                            formApi.setValues(values);
-                                        }}
                                         style={{
                                             marginTop: '5px',
                                             marginLeft: '10px',

--- a/web/src/pages/http-proxy/features/UpdateHttpProxy.tsx
+++ b/web/src/pages/http-proxy/features/UpdateHttpProxy.tsx
@@ -49,7 +49,7 @@ export default function UpdateHttpProxy({
     
     return (
         <Modal
-            title="新建HTTP代理"
+            title="修改HTTP代理"
             visible={visible}
             onCancel={onClose}
             fullScreen
@@ -109,7 +109,7 @@ export default function UpdateHttpProxy({
                                         }}
                                     ></Input>
                                 </Col>
-                                <Col span={4}>
+                                <Col span={2}>
                                     <Checkbox
                                         field="isHttps"
                                         initValue={values.isHttps}
@@ -117,7 +117,22 @@ export default function UpdateHttpProxy({
                                             values.isHttps = v;
                                             formApi.setValues(values);
                                         }}
-                                        label="使用HTTPS"
+                                        label="启用SSL"
+                                        style={{
+                                            marginTop: '10px',
+                                            marginLeft: '10px',
+                                        }}
+                                    ></Checkbox>
+                                </Col>
+                                <Col span={2}>
+                                    <Checkbox
+                                        field="redirectHttps"
+                                        label="强制跳转HTTPS"
+                                        initValue={values.redirectHttps}
+                                        onChange={(v: any) => {
+                                            values.redirectHttps = v;
+                                            formApi.setValues(values);
+                                        }}
                                         style={{
                                             marginTop: '10px',
                                             marginLeft: '10px',
@@ -133,23 +148,6 @@ export default function UpdateHttpProxy({
                                         label="启用流量监控"
                                         onChange={(v: any) => {
                                             values.enableFlowMonitoring = v;
-                                            formApi.setValues(values);
-                                        }}
-                                        style={{
-                                            marginTop: '5px',
-                                            marginLeft: '10px',
-                                        }}
-                                    ></Checkbox>
-                                </Col>
-                            </Row>
-                            <Row>
-                                <Col span={12}>
-                                    <Checkbox
-                                        field="redirectHttps"
-                                        label="启用HTTPS重定向"
-                                        initValue={values.redirectHttps}
-                                        onChange={(v: any) => {
-                                            values.redirectHttps = v;
                                             formApi.setValues(values);
                                         }}
                                         style={{


### PR DESCRIPTION
功能调整：
- `使用HTTPS`->`启用SSL`：勾选后，会同时监听80和443，这样就不用再额外添加个443的配置了。
- `启用HTTPS重定向`->`强制跳转HTTPS`：勾选后，访问80时，自动跳转到 HTTPS（443）。

页面调整如下图：

![image](https://github.com/239573049/FastGateway/assets/17940898/4ae7c9d4-2170-4d1a-8f73-6f4a07879e89)
