### PR TITLE
[bug fix] 新添加的域名在申请证书时，acme请求会自动跳转 HTTPS 导致验证失败；

### DIFF
--- a/src/FastGateway/Services/CertService.cs
+++ b/src/FastGateway/Services/CertService.cs
@@ -151,6 +151,7 @@ public static class CertService
 
                 for (int i = 0; i < 50; i++)
                 {
+                    Console.WriteLine($"{challenge.Url} | loop count: {i} | Status: {challenge.Status}");
                     if (challenge.Status == ChallengeStatus.Valid)
                     {
                         break;
@@ -158,6 +159,10 @@ public static class CertService
 
                     if (challenge.Status == ChallengeStatus.Invalid)
                     {
+                        if (challenge.Error != null)
+                        {
+                            Console.WriteLine($"域名 {domain} 验证失败！报错详情：{challenge.Error.Detail}");
+                        }
                         throw new Exception("验证失败，请检查域名是否正确配置");
                     }
 


### PR DESCRIPTION
- [bug fix] `80端口`在设置了`启用SSL`和`强制跳转HTTPS`之后，新添加的域名在申请证书时，`acme请求`会自动跳转 HTTPS 导致验证失败。修改为：把`acme请求`提到最前面进行处理。

- [update] 优化证书申请流程的信息展示。