### PR TITLE
修复 443被重复绑定；添加 http和https单端口双协议服务器

### DIFF
--- a/src/FastGateway/Middlewares/TlsDetection/ConnectionBuilderExtensions.cs
+++ b/src/FastGateway/Middlewares/TlsDetection/ConnectionBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿using KestrelFramework;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Connections
+{
+    /// <summary>
+    /// IConnectionBuilder扩展
+    /// </summary>
+    public static class ConnectionBuilderExtensions
+    {
+        /// <summary>
+        /// 使用Kestrel中间件
+        /// </summary>
+        /// <typeparam name="TMiddleware"></typeparam>
+        /// <param name="builder"></param>
+        /// <returns></returns>
+        public static IConnectionBuilder Use<TMiddleware>(this IConnectionBuilder builder)
+            where TMiddleware : IKestrelMiddleware
+        {
+            var middleware = ActivatorUtilities.GetServiceOrCreateInstance<TMiddleware>(builder.ApplicationServices);
+            return builder.Use(middleware);
+        }
+
+        /// <summary>
+        /// 使用Kestrel中间件
+        /// </summary> 
+        /// <param name="builder"></param>
+        /// <param name="middleware"></param>
+        /// <returns></returns>
+        public static IConnectionBuilder Use(this IConnectionBuilder builder, IKestrelMiddleware middleware)
+        {
+            return builder.Use(next => context => middleware.InvokeAsync(next, context));
+        }
+    }
+}

--- a/src/FastGateway/Middlewares/TlsDetection/FakeTlsConnectionFeature.cs
+++ b/src/FastGateway/Middlewares/TlsDetection/FakeTlsConnectionFeature.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Http.Features;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace KestrelFramework.Middleware.TlsDetection
+{
+    /// <summary>
+    /// 假冒的TlsConnectionFeature
+    /// </summary>
+    sealed class FakeTlsConnectionFeature : ITlsConnectionFeature
+    {
+        public static FakeTlsConnectionFeature Instance { get; } = new FakeTlsConnectionFeature();
+
+        public X509Certificate2? ClientCertificate
+        {
+            get => throw new NotImplementedException();
+            set => throw new NotImplementedException();
+        }
+
+        public Task<X509Certificate2?> GetClientCertificateAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/FastGateway/Middlewares/TlsDetection/IKestrelMiddleware.cs
+++ b/src/FastGateway/Middlewares/TlsDetection/IKestrelMiddleware.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Connections;
+using System.Threading.Tasks;
+
+namespace KestrelFramework
+{
+    /// <summary>
+    /// Kestrel的中间件接口
+    /// </summary>
+    public interface IKestrelMiddleware
+    {
+        /// <summary>
+        /// 执行
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        Task InvokeAsync(ConnectionDelegate next, ConnectionContext context);
+    }
+}

--- a/src/FastGateway/Middlewares/TlsDetection/ListenOptionsExtensions.cs
+++ b/src/FastGateway/Middlewares/TlsDetection/ListenOptionsExtensions.cs
@@ -1,0 +1,40 @@
+﻿using KestrelFramework.Middleware.TlsDetection;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+using System;
+
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// ListenOptions扩展
+    /// </summary>
+    public static partial class ListenOptionsExtensions
+    {
+        /// <summary>
+        /// 使用Tls侦测中间件
+        /// 效果是同一个端口支持某协议的非tls和tls两种流量
+        /// </summary>
+        /// <param name="listen"></param> 
+        /// <returns></returns>
+        public static ListenOptions UseTlsDetection(this ListenOptions listen)
+        {
+            return listen.UseTlsDetection(options => { });
+        }
+
+        /// <summary>
+        /// 使用Tls侦测中间件
+        /// 效果是同一个端口支持某协议的非tls和tls两种流量
+        /// </summary>
+        /// <param name="listen"></param>
+        /// <param name="configure">tls配置</param>
+        /// <returns></returns>
+        public static ListenOptions UseTlsDetection(this ListenOptions listen, Action<HttpsConnectionAdapterOptions> configure)
+        {
+            listen.Use<TlsInvadeMiddleware>();
+            listen.UseHttps(configure);
+            listen.Use<TlsRestoreMiddleware>();
+            return listen;
+        }
+    }
+}

--- a/src/FastGateway/Middlewares/TlsDetection/TlsInvadeMiddleware.cs
+++ b/src/FastGateway/Middlewares/TlsDetection/TlsInvadeMiddleware.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Threading.Tasks;
+
+namespace KestrelFramework.Middleware.TlsDetection
+{
+    /// <summary>
+    /// tls入侵中间件
+    /// </summary>
+    sealed class TlsInvadeMiddleware : IKestrelMiddleware
+    {
+        /// <summary>
+        /// 执行中间件
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public async Task InvokeAsync(ConnectionDelegate next, ConnectionContext context)
+        {
+            // 连接不是tls
+            if (await IsTlsConnectionAsync(context) == false)
+            {
+                // 没有任何tls中间件执行过
+                if (context.Features.Get<ITlsConnectionFeature>() == null)
+                {
+                    // 设置假的ITlsConnectionFeature，迫使https中间件跳过自身的工作
+                    context.Features.Set<ITlsConnectionFeature>(FakeTlsConnectionFeature.Instance);
+                }
+            }
+            await next(context);
+        }
+
+
+        /// <summary>
+        /// 是否为tls协议
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        private static async Task<bool> IsTlsConnectionAsync(ConnectionContext context)
+        {
+            try
+            {
+                var result = await context.Transport.Input.ReadAtLeastAsync(2, context.ConnectionClosed);
+                var state = IsTlsProtocol(result);
+                context.Transport.Input.AdvanceTo(result.Buffer.Start);
+                return state;
+            }
+            catch
+            {
+                return false;
+            }
+
+            static bool IsTlsProtocol(ReadResult result)
+            {
+                var reader = new SequenceReader<byte>(result.Buffer);
+                return reader.TryRead(out var firstByte) &&
+                    reader.TryRead(out var nextByte) &&
+                    firstByte == 0x16 &&
+                    nextByte == 0x3;
+            }
+        }
+    }
+}

--- a/src/FastGateway/Middlewares/TlsDetection/TlsRestoreMiddleware.cs
+++ b/src/FastGateway/Middlewares/TlsDetection/TlsRestoreMiddleware.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Http.Features;
+using System.Threading.Tasks;
+
+namespace KestrelFramework.Middleware.TlsDetection
+{
+    /// <summary>
+    /// tls恢复中间件
+    /// </summary>
+    sealed class TlsRestoreMiddleware : IKestrelMiddleware
+    {
+        /// <summary>
+        /// 执行中间件
+        /// </summary>
+        /// <param name="next"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public async Task InvokeAsync(ConnectionDelegate next, ConnectionContext context)
+        {
+            if (context.Features.Get<ITlsConnectionFeature>() == FakeTlsConnectionFeature.Instance)
+            {
+                // 擦除入侵
+                context.Features.Set<ITlsConnectionFeature>(null);
+            }
+            await next(context);
+        }
+    }
+}

--- a/src/FastGateway/Services/CertService.cs
+++ b/src/FastGateway/Services/CertService.cs
@@ -104,7 +104,7 @@ public static class CertService
             return ResultDto.ErrorResult("证书不存在");
         }
 
-        if (!ApiServiceService.HasHttpService)
+        if (!ApiServiceService.Has80Service)
         {
             return ResultDto.ErrorResult("请先添加一个80端口的HTTP服务");
         }


### PR DESCRIPTION
- [bug fix] `HasHttpService`是 静态全局变量，被当成 局部变量 使用了，导致 非80端口 在 启用SSL 时也会绑定 443，而不是它自己的端口，443被重复绑定导致app启动失败。
- [bug fix] `HasHttpService = false`从`finally`转为`catch`里。
- `HasHttpService`重命名为`Has80Service`；

- [feature]  非80端口 在 启用SSL 时，启用 http和https单端口双协议服务器。copy自[九佬的KestrelApp](https://github.com/xljiulang/KestrelApp/blob/master/KestrelFramework/Middleware/TlsDetection/ListenOptionsExtensions.cs)。