### PR TITLE
[feature] 添加 WebProxy网络代理 功能。当代理类型为 单个服务 时，才能设置。对 本机回环地址 会 绕过。

### DIFF
--- a/src/FastGateway/Domain/Location.cs
+++ b/src/FastGateway/Domain/Location.cs
@@ -68,6 +68,15 @@ public sealed class LocationService
 
     [Column(MapType = typeof(string), StringLength = -1)]
     public List<UpStream> UpStreams { get; set; } = new();
+
+    #region ApiServiceType.SingleService时使用
+
+    /// <summary>
+    /// Web代理服务（ApiServiceType.SingleService时使用）
+    /// </summary>
+    public string? WebProxy { get; set; }
+
+    #endregion
 }
 
 public sealed class UpStream

--- a/src/FastGateway/Dto/LocationInput.cs
+++ b/src/FastGateway/Dto/LocationInput.cs
@@ -3,7 +3,7 @@
 public class LocationInput
 {
     public string? Id { get; set; }
-    
+
     /// <summary>
     /// 绑定服务ID
     /// </summary>
@@ -23,7 +23,7 @@ public sealed class LocationServiceDto
     /// </summary>
     [Column(MapType = typeof(string), StringLength = -1)]
     public Dictionary<string, string> AddHeader { get; set; } = new();
-    
+
     /// <summary>
     /// 静态文件或目录
     /// </summary>
@@ -54,6 +54,15 @@ public sealed class LocationServiceDto
 
     [Column(MapType = typeof(string), StringLength = -1)]
     public List<UpStreamInput> UpStreams { get; set; } = new();
+
+    #region ApiServiceType.SingleService时使用
+
+    /// <summary>
+    /// Web代理服务（ApiServiceType.SingleService时使用）
+    /// </summary>
+    public string? WebProxy { get; set; }
+
+    #endregion
 }
 
 public class UpStreamInput

--- a/src/FastGateway/Services/ApiServiceService.cs
+++ b/src/FastGateway/Services/ApiServiceService.cs
@@ -106,7 +106,8 @@ public static class ApiServiceService
                     {
                         Server = x.Server,
                         Weight = x.Weight
-                    }).ToList()
+                    }).ToList(),
+                    WebProxy = x.WebProxy,
                 }).ToList()
             }).ToList()
         };
@@ -155,6 +156,7 @@ public static class ApiServiceService
                     Weight = x.Weight
                 }).ToList(),
                 LoadType = x.LoadType,
+                WebProxy = x.WebProxy,
             }).ToList()
         })).ExecuteAffrowsAsync();
     }
@@ -715,13 +717,29 @@ public static class ApiServiceService
 
                 #endregion
 
+                #region WebProxy
+
+                WebProxyConfig? webProxy = null;
+                if (locationService.Type == ApiServiceType.SingleService && !string.IsNullOrWhiteSpace(locationService.WebProxy))
+                {
+                    webProxy = new()
+                    {
+                        Address = new Uri(locationService.WebProxy),
+                        BypassOnLocal = true,
+                        UseDefaultCredentials = false
+                    };
+                }
+
+                #endregion
+
                 string id = $"{location.Id}-{i}";
                 var destinations = new Dictionary<string, DestinationConfig>();
                 var cluster = new ClusterConfig()
                 {
                     Destinations = destinations,
                     ClusterId = id,
-                    Metadata = clusterMetadata
+                    Metadata = clusterMetadata,
+                    HttpClient = new() { WebProxy = webProxy },
                 };
                 clusters.Add(cluster);
 

--- a/web/src/module.ts
+++ b/web/src/module.ts
@@ -33,6 +33,7 @@ export interface LocationServiceDto {
     type: ApiServiceType;
     loadType: LoadType;
     upStreams: UpStreamInput[];
+    webProxy: string | null;
 }
 
 export enum ApiServiceType {

--- a/web/src/pages/http-proxy/features/CreateHttpProxy.tsx
+++ b/web/src/pages/http-proxy/features/CreateHttpProxy.tsx
@@ -324,6 +324,7 @@ export default function CreateHttpProxy({
                                                     loadType: 1,
                                                     upStreams: [],
                                                     root: '',
+                                                    webProxy: '',
                                                 });
                                                 formApi.setValues(values);
                                             }}>
@@ -438,15 +439,26 @@ export default function CreateHttpProxy({
                                                             }
                                                             {
                                                                 service.type === 2 && (
-                                                                    <Input
-                                                                        label="代理地址"
-                                                                        initValue={service.proxyPass}
-                                                                        defaultValue={service.proxyPass}
-                                                                        onChange={(v: any) => {
-                                                                            service.proxyPass = v;
-                                                                            formApi.setValues(values);
-                                                                        }}
-                                                                        field="proxyPass" />
+                                                                    <>
+                                                                        <Input
+                                                                            label="代理地址"
+                                                                            initValue={service.proxyPass}
+                                                                            defaultValue={service.proxyPass}
+                                                                            onChange={(v: any) => {
+                                                                                service.proxyPass = v;
+                                                                                formApi.setValues(values);
+                                                                            }}
+                                                                            field="proxyPass" />
+                                                                        <Input
+                                                                            label="WebProxy"
+                                                                            initValue={service.webProxy}
+                                                                            defaultValue={service.webProxy}
+                                                                            onChange={(v: any) => {
+                                                                                service.webProxy = v;
+                                                                                formApi.setValues(values);
+                                                                            }}
+                                                                            field="webProxy" />
+                                                                    </>
                                                                 )
                                                             }
                                                             {

--- a/web/src/pages/http-proxy/features/UpdateHttpProxy.tsx
+++ b/web/src/pages/http-proxy/features/UpdateHttpProxy.tsx
@@ -338,6 +338,7 @@ export default function UpdateHttpProxy({
                                                     loadType: 1,
                                                     upStreams: [],
                                                     root: '',
+                                                    webProxy: '',
                                                 });
                                                 formApi.setValues(values);
                                             }}>
@@ -452,16 +453,27 @@ export default function UpdateHttpProxy({
                                                             }
                                                             {
                                                                 service.type === 2 && (
-                                                                    <AutoComplete
-                                                                        label="代理地址"
-                                                                        data={clients}
-                                                                        initValue={service.proxyPass}
-                                                                        defaultValue={service.proxyPass}
-                                                                        onChange={(v: any) => {
-                                                                            service.proxyPass = v;
-                                                                            formApi.setValues(values);
-                                                                        }}
-                                                                        field="proxyPass" />
+                                                                    <>
+                                                                        <AutoComplete
+                                                                            label="代理地址"
+                                                                            data={clients}
+                                                                            initValue={service.proxyPass}
+                                                                            defaultValue={service.proxyPass}
+                                                                            onChange={(v: any) => {
+                                                                                service.proxyPass = v;
+                                                                                formApi.setValues(values);
+                                                                            }}
+                                                                            field="proxyPass" />
+                                                                        <Input
+                                                                            label="WebProxy"
+                                                                            initValue={service.webProxy}
+                                                                            defaultValue={service.webProxy}
+                                                                            onChange={(v: any) => {
+                                                                                service.webProxy = v;
+                                                                                formApi.setValues(values);
+                                                                            }}
+                                                                            field="webProxy" />
+                                                                    </>
                                                                 )
                                                             }
                                                             {


### PR DESCRIPTION
添加 WebProxy网络代理 功能。当代理类型为`单个服务`时，才能设置。对`本机回环地址`会绕过。

![image](https://github.com/239573049/FastGateway/assets/17940898/69df6bb8-7580-4bc5-895c-c7fe8a0e75ab)
