### PR TITLE
feat(cert): 支持上传自定义证书、泛域名 DNS-01 及修复 HTTPS 重定向

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,10 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main", "master" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main", "master" ]
+  workflow_dispatch:
 
 jobs:
   build-and-push:
@@ -45,8 +46,10 @@ jobs:
         with:
           context: .
           file: src/FastGateway/Dockerfile
-          platforms: linux/amd64
-          push: true
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             aidotnet/fast-gateway:latest
             aidotnet/fast-gateway:sha-${{ steps.vars.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,15 +51,28 @@ jobs:
     name: Build TunnelClient
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             runtime: linux-x64
             arch: amd64
+          - os: ubuntu-latest
+            runtime: linux-arm64
+            arch: arm64
           - os: windows-latest
             runtime: win-x64
             arch: amd64
-    
+          - os: windows-latest
+            runtime: win-arm64
+            arch: arm64
+          - os: macos-latest
+            runtime: osx-x64
+            arch: amd64
+          - os: macos-latest
+            runtime: osx-arm64
+            arch: arm64
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,15 +100,28 @@ jobs:
     needs: build-web
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             runtime: linux-x64
             arch: amd64
+          - os: ubuntu-latest
+            runtime: linux-arm64
+            arch: arm64
           - os: windows-latest
             runtime: win-x64
             arch: amd64
-    
+          - os: windows-latest
+            runtime: win-arm64
+            arch: arm64
+          - os: macos-latest
+            runtime: osx-x64
+            arch: amd64
+          - os: macos-latest
+            runtime: osx-arm64
+            arch: arm64
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -173,20 +199,28 @@ jobs:
         run: |
           cat > release-notes.md << 'EOF'
           ## Release ${{ github.ref_name || github.event.inputs.version }}
-          
+
           ### Downloads
-          
-          #### TunnelClient
-          - **Linux AMD64**: `tunnelclient-linux-x64.tar.gz`
-          - **Windows AMD64**: `tunnelclient-win-x64.zip`
-          
+
           #### FastGateway
-          - **Linux AMD64**: `fastgateway-linux-x64.tar.gz`
-          - **Windows AMD64**: `fastgateway-win-x64.zip`
-          
+          - **Linux x64**: `fastgateway-linux-x64.tar.gz`
+          - **Linux ARM64**: `fastgateway-linux-arm64.tar.gz`
+          - **Windows x64**: `fastgateway-win-x64.zip`
+          - **Windows ARM64**: `fastgateway-win-arm64.zip`
+          - **macOS x64 (Intel)**: `fastgateway-osx-x64.tar.gz`
+          - **macOS ARM64 (Apple Silicon)**: `fastgateway-osx-arm64.tar.gz`
+
+          #### TunnelClient
+          - **Linux x64**: `tunnelclient-linux-x64.tar.gz`
+          - **Linux ARM64**: `tunnelclient-linux-arm64.tar.gz`
+          - **Windows x64**: `tunnelclient-win-x64.zip`
+          - **Windows ARM64**: `tunnelclient-win-arm64.zip`
+          - **macOS x64 (Intel)**: `tunnelclient-osx-x64.tar.gz`
+          - **macOS ARM64 (Apple Silicon)**: `tunnelclient-osx-arm64.tar.gz`
+
           ### Features
-          - Cross-platform support for Linux and Windows
-          - AMD64 architecture support
+          - Cross-platform support for Linux, Windows and macOS
+          - x64 and ARM64 architecture support
           - TunnelClient: Single-file executable for optimal portability
           - FastGateway: Single-file executable with all dependencies included
           

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -8,8 +8,10 @@ FastGateway提供了基本的管理服务，提供简单的登录授权，和实
 ## 支持功能
 
 - [x] 登录授权
-- [x] 自动申请HTTPS证书
+- [x] 自动申请HTTPS证书（Let's Encrypt / HTTP-01）
 - [x] 自动续期HTTPS证书
+- [x] 泛域名证书（Let's Encrypt / DNS-01）
+- [x] 上传自定义HTTPS证书（PFX / PEM）
 - [x] dashboard监控
 - [x] 静态文件服务
 - [x] 单服务代理
@@ -19,11 +21,25 @@ FastGateway提供了基本的管理服务，提供简单的登录授权，和实
 - [x] 支持自定义限流策略
 - [x] 支持黑白名单
 
+## HTTPS 证书管理
+
+FastGateway 在「证书管理」页面提供三种方式为域名配置 HTTPS 证书：
+
+1. **自动申请（Let's Encrypt，HTTP-01）** — 对于普通域名（如 `example.com`），填写域名与邮箱后点击「申请证书」，网关会自动完成 ACME HTTP-01 验证（需要开启 80 端口服务），并在证书临期前自动续期。
+
+2. **泛域名证书（Let's Encrypt，DNS-01）** — 泛域名（如 `*.example.com`）无法使用 HTTP-01 验证。新增域名后点击「DNS 验证」，网关会生成一条 `_acme-challenge` TXT 记录，请将其添加到域名解析服务商；记录生效后点击「验证并签发」即可完成签发。此方式签发的泛域名证书不会自动续期，到期前需再次通过 DNS 验证。
+
+3. **上传自定义证书** — 点击「上传证书」使用你已有的证书，支持两种格式：
+   - **PFX / P12** — 上传 `.pfx`/`.p12` 文件及其密码（无密码可留空）。
+   - **PEM / CRT** — 分别上传证书文件（`.pem`/`.crt`）与私钥文件（`.key`）。
+
+   上传的证书（包括泛域名）按 SNI 匹配，不参与自动续期，到期前请重新上传。上传的证书会统一转换为 `.pfx` 保存在 `certs` 目录下。
+
 ## 技术栈
 
 ### 后端技术栈
 
-- Asp.Net 8.0 用于提供基础服务
+- .NET 10 用于提供基础服务
 - Yarp 用于提供反向代理服务
 - FreeSql用于提供数据库服务
 - JWT 用于提供登录授权服务
@@ -148,11 +164,19 @@ systemctl stop fastgateway.service
 systemctl restart fastgateway.service
 ```
 
-## 镜像列表
+## 下载
 
-- 默认镜像：hejiale010426/gateway-api:v1.0.0
-- 提供HTTP3镜像：hejiale010426/gateway-api:v1.0.0-h3
-- ARM64镜像：hejiale010426/gateway-api:v1.0.0-arm64
+[Releases](../../releases) 页面提供以下平台的自包含（self-contained）预编译包：
+
+| 操作系统 | x64 | ARM64 |
+| --- | --- | --- |
+| Linux | `fastgateway-linux-x64.tar.gz` | `fastgateway-linux-arm64.tar.gz` |
+| Windows | `fastgateway-win-x64.zip` | `fastgateway-win-arm64.zip` |
+| macOS | `fastgateway-osx-x64.tar.gz` | `fastgateway-osx-arm64.tar.gz` |
+
+`TunnelClient` 组件同样提供上述所有平台的压缩包（`tunnelclient-<runtime>`）。
+
+Docker 镜像 `aidotnet/fast-gateway` 为多架构镜像，同时支持 `linux/amd64` 与 `linux/arm64`，`docker run`/`docker compose` 会自动拉取与主机匹配的版本。
 
 ## 第三方下载
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Document Language: [English](README.md) | [简体中文](README-zh-cn.md)
 ## Supported Features
 
 - [x] Login authorization
-- [x] Automatic HTTPS certificate application
+- [x] Automatic HTTPS certificate application (Let's Encrypt / HTTP-01)
 - [x] Automatic HTTPS certificate renewal
+- [x] Wildcard domain certificates (Let's Encrypt / DNS-01)
+- [x] Upload custom HTTPS certificates (PFX / PEM)
 - [x] Dashboard monitoring
 - [x] Static file service
 - [x] Single service proxy
@@ -19,11 +21,25 @@ Document Language: [English](README.md) | [简体中文](README-zh-cn.md)
 - [x] Support for custom rate limiting policies
 - [x] Support for black and white lists
 
+## HTTPS Certificate Management
+
+FastGateway supports three ways to provide HTTPS certificates for your domains, all managed from the **Certificate Management** page:
+
+1. **Automatic (Let's Encrypt, HTTP-01)** — For a normal domain (e.g. `example.com`), add the domain and email, then click **Apply**. The gateway completes the ACME HTTP-01 challenge automatically (an enabled port-80 service is required) and renews the certificate before it expires.
+
+2. **Wildcard domain (Let's Encrypt, DNS-01)** — For a wildcard domain (e.g. `*.example.com`), HTTP-01 cannot be used. Add the domain, then click **DNS Verify**: the gateway generates a `_acme-challenge` TXT record for you to add at your DNS provider. Once the record has propagated, click **Verify & Issue** to complete the challenge. Wildcard certificates issued this way are not auto-renewed — re-run the DNS verification before they expire.
+
+3. **Upload your own certificate** — Click **Upload Certificate** to use a certificate you already own. Two formats are supported:
+   - **PFX / P12** — upload the `.pfx`/`.p12` file together with its password (leave empty if it has none).
+   - **PEM / CRT** — upload the certificate (`.pem`/`.crt`) and its private key (`.key`) separately.
+
+   Uploaded certificates (including wildcard ones) are matched by SNI and do not participate in automatic renewal; upload a new file before expiry. Uploaded certificates are converted to and stored as `.pfx` under the `certs` directory.
+
 ## Technology Stack
 
 ### Backend Technology Stack
 
-- Asp.Net 8.0 for providing basic services
+- .NET 10 for providing basic services
 - Yarp for providing reverse proxy services
 - FreeSql for database services
 - JWT for login authorization services
@@ -147,6 +163,20 @@ If you have made changes to the service and need to reload the configuration, yo
 ```shell
 systemctl restart fastgateway.service
 ```
+
+## Downloads
+
+Pre-built, self-contained binaries are published on the [Releases](../../releases) page for the following platforms:
+
+| OS | x64 | ARM64 |
+| --- | --- | --- |
+| Linux | `fastgateway-linux-x64.tar.gz` | `fastgateway-linux-arm64.tar.gz` |
+| Windows | `fastgateway-win-x64.zip` | `fastgateway-win-arm64.zip` |
+| macOS | `fastgateway-osx-x64.tar.gz` | `fastgateway-osx-arm64.tar.gz` |
+
+The `TunnelClient` component is published for the same set of platforms (`tunnelclient-<runtime>` archives).
+
+The Docker image `aidotnet/fast-gateway` is a multi-arch image supporting both `linux/amd64` and `linux/arm64`, so `docker run`/`docker compose` automatically pulls the right variant for your host.
 
 ## Third-Party Downloads
 

--- a/src/Core/Entities/Cert.cs
+++ b/src/Core/Entities/Cert.cs
@@ -9,6 +9,11 @@ public sealed class Cert
     public string Domain { get; set; }
 
     /// <summary>
+    /// 证书来源类型（Let's Encrypt 自动申请 / 用户上传）
+    /// </summary>
+    public CertType Type { get; set; }
+
+    /// <summary>
     /// 是否过期
     /// </summary>
     public bool Expired { get; set; }

--- a/src/Core/Entities/Core/CertType.cs
+++ b/src/Core/Entities/Core/CertType.cs
@@ -1,0 +1,17 @@
+namespace Core.Entities.Core;
+
+/// <summary>
+/// 证书来源类型
+/// </summary>
+public enum CertType : byte
+{
+    /// <summary>
+    /// Let's Encrypt 自动申请
+    /// </summary>
+    LetsEncrypt = 0,
+
+    /// <summary>
+    /// 用户上传的自定义证书
+    /// </summary>
+    Custom = 1,
+}

--- a/src/FastGateway/BackgroundTask/RenewSSLBackgroundService.cs
+++ b/src/FastGateway/BackgroundTask/RenewSSLBackgroundService.cs
@@ -1,4 +1,5 @@
-﻿using FastGateway.Services;
+﻿using Core.Entities.Core;
+using FastGateway.Services;
 
 namespace FastGateway.BackgroundTask;
 
@@ -21,7 +22,10 @@ public class RenewSslBackgroundService(ILogger<RenewSslBackgroundService> logger
                     var configService = scope.ServiceProvider.GetRequiredService<ConfigurationService>();
 
                     // 查询所有需要续期的证书
+                    // 自定义上传的证书不参与自动续期；泛域名证书只能通过 DNS-01 手动验证，无法自动续期
                     var certs = configService.GetCerts()
+                        .Where(x => x.Type != CertType.Custom)
+                        .Where(x => !x.Domain.StartsWith("*."))
                         .Where(x => x.NotAfter == null || (x.NotAfter < DateTime.Now.AddDays(15) && x.AutoRenew))
                         .ToArray();
 

--- a/src/FastGateway/Gateway/Gateway.cs
+++ b/src/FastGateway/Gateway/Gateway.cs
@@ -111,8 +111,28 @@ public static class Gateway
     public static void InvalidateCertificate(string domain)
     {
         if (string.IsNullOrWhiteSpace(domain)) return;
-        var key = $"sni:{domain.Trim().ToLowerInvariant()}";
-        if (CertificateCache.TryRemove(key, out var cert))
+        var normalized = domain.Trim().ToLowerInvariant();
+
+        // 泛域名证书：清除所有匹配该泛域名的 SNI 缓存（如 *.example.com 对应 a.example.com、b.example.com 等）
+        if (normalized.StartsWith("*."))
+        {
+            var suffix = normalized[1..]; // ".example.com"
+            foreach (var key in CertificateCache.Keys)
+            {
+                if (!key.StartsWith("sni:")) continue;
+                var host = key["sni:".Length..];
+                if (host != normalized && !host.EndsWith(suffix)) continue;
+                if (CertificateCache.TryRemove(key, out var wildcardCert))
+                {
+                    try { wildcardCert.Dispose(); } catch { /* ignore */ }
+                }
+            }
+
+            return;
+        }
+
+        var exactKey = $"sni:{normalized}";
+        if (CertificateCache.TryRemove(exactKey, out var cert))
         {
             try { cert.Dispose(); } catch { /* ignore */ }
         }
@@ -485,6 +505,24 @@ public static class Gateway
                         await CertService.Challenge(context, token.Value![1..]);
                     else
                         await next.Invoke();
+                });
+
+            // HTTPS 重定向：将 80 端口的明文请求重定向到 HTTPS
+            // 放在 ACME 校验之后，避免影响 HTTP-01 证书签发
+            if (is80 && server is { IsHttps: true, RedirectHttps: true })
+                app.Use(async (context, next) =>
+                {
+                    if (!context.Request.IsHttps)
+                    {
+                        var host = context.Request.Host.Host;
+                        var location =
+                            $"https://{host}{context.Request.PathBase}{context.Request.Path}{context.Request.QueryString}";
+                        context.Response.StatusCode = StatusCodes.Status307TemporaryRedirect;
+                        context.Response.Headers.Location = location;
+                        return;
+                    }
+
+                    await next.Invoke();
                 });
 
             app.UseInitGatewayMiddleware();

--- a/src/FastGateway/Services/CertService.cs
+++ b/src/FastGateway/Services/CertService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
+using System.Security.Cryptography.X509Certificates;
 using Certes;
 using Certes.Acme;
 using Certes.Acme.Resource;
@@ -36,9 +37,39 @@ public static class CertService
         context.Response.StatusCode = 404;
     }
 
-    public static Cert? GetCert(string domain)
+    public static Cert? GetCert(string? domain)
     {
-        return CertWebApplications.TryGetValue(domain, out var cert) ? cert : null;
+        if (string.IsNullOrWhiteSpace(domain)) return null;
+
+        var host = domain.Trim().ToLowerInvariant();
+
+        // 精确匹配优先
+        foreach (var pair in CertWebApplications)
+            if (string.Equals(pair.Key, host, StringComparison.OrdinalIgnoreCase))
+                return pair.Value;
+
+        // 泛域名匹配：a.example.com -> *.example.com（仅匹配一级子域名）
+        var index = host.IndexOf('.');
+        if (index > 0 && index < host.Length - 1)
+        {
+            var wildcard = "*." + host[(index + 1)..];
+            foreach (var pair in CertWebApplications)
+                if (string.Equals(pair.Key, wildcard, StringComparison.OrdinalIgnoreCase))
+                    return pair.Value;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// 生成安全的证书文件名，处理泛域名（*）及其它非法文件名字符。
+    /// </summary>
+    private static string SafeCertFileName(string domain)
+    {
+        var name = domain.Replace("*", "_wildcard_");
+        foreach (var c in Path.GetInvalidFileNameChars())
+            name = name.Replace(c, '_');
+        return name;
     }
 
     public static void InitCert(Cert[] certs)
@@ -82,6 +113,10 @@ public static class CertService
         var cert = configService.GetCerts().FirstOrDefault(x => x.Id == id);
 
         if (cert == null) return ResultDto.CreateFailed("证书不存在");
+
+        if (cert.Type == CertType.Custom) return ResultDto.CreateFailed("自定义上传的证书不支持自动申请，请重新上传证书文件");
+
+        if (cert.Domain.StartsWith("*.")) return ResultDto.CreateFailed("泛域名证书请使用 DNS 验证方式申请");
 
         if (!Gateway.Gateway.Has80Service) return ResultDto.CreateFailed("请先80端口服务，再申请证书，否则无法验证域名");
 
@@ -154,7 +189,7 @@ public static class CertService
             if (!Directory.Exists(certPath)) Directory.CreateDirectory(certPath);
 
             // 保存证书文件
-            var certFile = Path.Combine(certPath, $"{certItem.Domain}.pfx");
+            var certFile = Path.Combine(certPath, $"{SafeCertFileName(certItem.Domain)}.pfx");
             await File.WriteAllBytesAsync(certFile, pfx);
 
             // 更新证书信息
@@ -177,6 +212,243 @@ public static class CertService
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// 准备 DNS-01 验证（用于泛域名等无法通过 HTTP-01 验证的场景）。
+    /// 生成 _acme-challenge TXT 记录供用户手动添加到域名解析。
+    /// </summary>
+    public static async Task<ResultDto> PrepareDnsChallengeAsync(ConfigurationService configService, string id)
+    {
+        var cert = configService.GetCerts().FirstOrDefault(x => x.Id == id);
+        if (cert == null) return ResultDto.CreateFailed("证书不存在");
+        if (cert.Type == CertType.Custom) return ResultDto.CreateFailed("自定义上传的证书无需申请");
+        if (string.IsNullOrWhiteSpace(cert.Email)) return ResultDto.CreateFailed("请先为该证书配置邮箱");
+
+        try
+        {
+            var context = await RegisterWithLetsEncrypt(cert.Email);
+            var order = await context.NewOrder(new[] { cert.Domain });
+            var authz = (await order.Authorizations()).First();
+            var dnsChallenge = await authz.Dns();
+            var dnsTxt = context.AccountKey.DnsTxt(dnsChallenge.Token);
+
+            // 泛域名 *.example.com 的验证记录为 _acme-challenge.example.com
+            var baseDomain = cert.Domain.StartsWith("*.") ? cert.Domain[2..] : cert.Domain;
+            var recordName = "_acme-challenge." + baseDomain;
+
+            // 缓存订单地址，供 validate 步骤续用（30 分钟内有效）
+            MemoryCache.Set($"dns-order:{cert.Id}", order.Location.ToString(), TimeSpan.FromMinutes(30));
+
+            return ResultDto.CreateSuccess(new
+            {
+                recordName,
+                recordType = "TXT",
+                recordValue = dnsTxt
+            });
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return ResultDto.CreateFailed("获取 DNS 验证记录失败：" + e.Message);
+        }
+    }
+
+    /// <summary>
+    /// 校验 DNS-01 记录并签发证书。用户在添加 TXT 记录后调用。
+    /// </summary>
+    public static async Task<ResultDto> ValidateDnsChallengeAsync(ConfigurationService configService, string id)
+    {
+        var cert = configService.GetCerts().FirstOrDefault(x => x.Id == id);
+        if (cert == null) return ResultDto.CreateFailed("证书不存在");
+
+        if (!MemoryCache.TryGetValue($"dns-order:{cert.Id}", out var cached) || cached is not string orderUri)
+            return ResultDto.CreateFailed("验证信息已过期，请重新获取 DNS 记录");
+
+        try
+        {
+            var context = await RegisterWithLetsEncrypt(cert.Email);
+            var order = context.Order(new Uri(orderUri));
+            var authz = (await order.Authorizations()).First();
+            var dnsChallenge = await authz.Dns();
+
+            var challenge = await dnsChallenge.Validate();
+            for (var i = 0; i < 30; i++)
+            {
+                if (challenge.Status == ChallengeStatus.Valid) break;
+                if (challenge.Status == ChallengeStatus.Invalid)
+                {
+                    cert.RenewStats = RenewStats.Fail;
+                    configService.UpdateCert(cert);
+                    return ResultDto.CreateFailed("DNS 验证失败：" + (challenge.Error?.Detail ?? "请检查 TXT 记录是否已生效"));
+                }
+
+                await Task.Delay(5000);
+                challenge = await dnsChallenge.Resource();
+            }
+
+            if (challenge.Status != ChallengeStatus.Valid)
+                return ResultDto.CreateFailed("DNS 验证超时，请确认 TXT 记录已生效后重试");
+
+            var privateKey = KeyFactory.NewKey(KeyAlgorithm.ES256);
+            var certChain = await order.Generate(new CsrInfo { CommonName = cert.Domain }, privateKey);
+
+            const string certPassword = "Aa123456";
+            var pfx = certChain.ToPfx(privateKey).Build("my-cert", certPassword);
+
+            var certPath = Path.Combine(AppContext.BaseDirectory, "certs");
+            if (!Directory.Exists(certPath)) Directory.CreateDirectory(certPath);
+            var certFile = Path.Combine(certPath, $"{SafeCertFileName(cert.Domain)}.pfx");
+            await File.WriteAllBytesAsync(certFile, pfx);
+
+            cert.NotAfter = DateTime.Now.AddMonths(3);
+            cert.RenewTime = DateTime.Now;
+            cert.Expired = false;
+            cert.Type = CertType.LetsEncrypt;
+            cert.RenewStats = RenewStats.Success;
+            cert.Certs = new CertData { File = certFile, Domain = cert.Domain, Password = certPassword };
+
+            configService.UpdateCert(cert);
+            MemoryCache.Remove($"dns-order:{cert.Id}");
+            CertWebApplications[cert.Domain] = cert;
+            Gateway.Gateway.InvalidateCertificate(cert.Domain);
+
+            return ResultDto.CreateSuccess();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return ResultDto.CreateFailed("签发证书失败：" + e.Message);
+        }
+    }
+
+    /// <summary>
+    /// 上传用户自定义证书（支持 pfx/p12 与 pem 格式），统一转换为固定密码的 pfx 后落盘。
+    /// </summary>
+    public static async Task<ResultDto> UploadAsync(ConfigurationService configService, HttpRequest request)
+    {
+        if (!request.HasFormContentType)
+            return ResultDto.CreateFailed("请使用 multipart/form-data 上传证书");
+
+        var form = await request.ReadFormAsync();
+
+        var domain = form["domain"].ToString().Trim();
+        if (string.IsNullOrWhiteSpace(domain))
+            return ResultDto.CreateFailed("域名不能为空");
+
+        var id = form["id"].ToString();
+        var certType = form["certType"].ToString().Trim().ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(certType)) certType = "pfx";
+
+        var existing = configService.GetCerts().FirstOrDefault(x => x.Id == id);
+        var previousDomain = existing?.Domain;
+
+        // 域名唯一性校验（排除自身）
+        if (configService.GetCerts().Any(x => x.Domain == domain && x.Id != existing?.Id))
+            return ResultDto.CreateFailed("域名已存在");
+
+        // 统一使用固定密码保存，保持与自动申请证书一致，SNI 加载时无需用户密码
+        const string storagePassword = "Aa123456";
+        byte[] pfxBytes;
+
+        try
+        {
+            if (certType == "pem")
+            {
+                var certFile = form.Files["file"];
+                var keyFile = form.Files["keyFile"];
+                if (certFile == null || certFile.Length == 0)
+                    return ResultDto.CreateFailed("请上传证书文件（.pem/.crt）");
+                if (keyFile == null || keyFile.Length == 0)
+                    return ResultDto.CreateFailed("请上传证书私钥文件（.key）");
+
+                var certPem = await ReadAllTextAsync(certFile);
+                var keyPem = await ReadAllTextAsync(keyFile);
+
+                using var fromPem = X509Certificate2.CreateFromPem(certPem, keyPem);
+                pfxBytes = fromPem.Export(X509ContentType.Pfx, storagePassword);
+            }
+            else
+            {
+                var pfxFile = form.Files["file"];
+                if (pfxFile == null || pfxFile.Length == 0)
+                    return ResultDto.CreateFailed("请上传证书文件（.pfx/.p12）");
+
+                var password = form["password"].ToString();
+                var rawBytes = await ReadAllBytesAsync(pfxFile);
+
+                // 导入后重新导出为固定密码的 pfx，并保留完整证书链
+                var collection = new X509Certificate2Collection();
+                collection.Import(rawBytes, password,
+                    X509KeyStorageFlags.Exportable | X509KeyStorageFlags.EphemeralKeySet);
+                pfxBytes = collection.Export(X509ContentType.Pfx, storagePassword)!;
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return ResultDto.CreateFailed("证书解析失败，请检查文件格式和密码是否正确");
+        }
+
+        // 重新加载以读取证书元数据并校验私钥
+        using var certificate = new X509Certificate2(pfxBytes, storagePassword, X509KeyStorageFlags.EphemeralKeySet);
+        if (!certificate.HasPrivateKey)
+            return ResultDto.CreateFailed("上传的证书缺少私钥，无法用于 HTTPS");
+
+        // 保存证书文件
+        var certPath = Path.Combine(AppContext.BaseDirectory, "certs");
+        if (!Directory.Exists(certPath)) Directory.CreateDirectory(certPath);
+        var savePath = Path.Combine(certPath, $"{SafeCertFileName(domain)}.pfx");
+        await File.WriteAllBytesAsync(savePath, pfxBytes);
+
+        var target = existing ?? new Cert { CreateTime = DateTime.Now };
+        target.Domain = domain;
+        target.Type = CertType.Custom;
+        target.AutoRenew = false;
+        target.Expired = certificate.NotAfter < DateTime.Now;
+        target.NotAfter = certificate.NotAfter;
+        target.Issuer = certificate.GetNameInfo(X509NameType.SimpleName, true);
+        target.RenewTime = DateTime.Now;
+        target.RenewStats = RenewStats.Success;
+        var email = form["email"].ToString();
+        if (!string.IsNullOrWhiteSpace(email)) target.Email = email;
+        target.Certs = new CertData
+        {
+            File = savePath,
+            Domain = domain,
+            Password = storagePassword
+        };
+
+        if (existing == null)
+            configService.AddCert(target);
+        else
+            configService.UpdateCert(target);
+
+        // 域名发生变更时，清理旧域名的内存证书与网关缓存，避免残留
+        if (previousDomain != null && !string.Equals(previousDomain, domain, StringComparison.OrdinalIgnoreCase))
+        {
+            CertWebApplications.TryRemove(previousDomain, out _);
+            Gateway.Gateway.InvalidateCertificate(previousDomain);
+        }
+
+        // 更新内存证书并清除网关缓存以立即生效
+        CertWebApplications[domain] = target;
+        Gateway.Gateway.InvalidateCertificate(domain);
+
+        return ResultDto.CreateSuccess();
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(IFormFile file)
+    {
+        using var ms = new MemoryStream();
+        await file.CopyToAsync(ms);
+        return ms.ToArray();
+    }
+
+    private static async Task<string> ReadAllTextAsync(IFormFile file)
+    {
+        using var reader = new StreamReader(file.OpenReadStream());
+        return await reader.ReadToEndAsync();
     }
 
     public static IEndpointRouteBuilder MapCert(this IEndpointRouteBuilder app)
@@ -243,6 +515,22 @@ public static class CertService
         cert.MapPost("{id}/apply",
                 async (ConfigurationService configService, string id) => await ApplyAsync(configService, id))
             .WithDescription("申请证书").WithDisplayName("申请证书").WithTags("证书");
+
+        cert.MapPost("upload",
+                async (ConfigurationService configService, HttpRequest request) =>
+                    await UploadAsync(configService, request))
+            .WithDescription("上传自定义证书").WithDisplayName("上传自定义证书").WithTags("证书")
+            .DisableAntiforgery();
+
+        cert.MapPost("{id}/dns/prepare",
+                async (ConfigurationService configService, string id) =>
+                    await PrepareDnsChallengeAsync(configService, id))
+            .WithDescription("获取DNS验证记录").WithDisplayName("获取DNS验证记录").WithTags("证书");
+
+        cert.MapPost("{id}/dns/validate",
+                async (ConfigurationService configService, string id) =>
+                    await ValidateDnsChallengeAsync(configService, id))
+            .WithDescription("校验DNS并签发证书").WithDisplayName("校验DNS并签发证书").WithTags("证书");
 
         return app;
     }

--- a/web/src/pages/cert/features/CreateCert.tsx
+++ b/web/src/pages/cert/features/CreateCert.tsx
@@ -86,9 +86,12 @@ export default function CreateCertPage({
                             onChange={(e) =>
                                 setValue({ ...value, domain: e.target.value })
                             }
-                            placeholder="请输入域名，如 example.com"
+                            placeholder="请输入域名，如 example.com 或 *.example.com"
                             className="w-full"
                         />
+                        <p className="text-xs text-muted-foreground">
+                            支持泛域名（如 *.example.com），泛域名需在列表中通过「DNS 验证」方式申请。
+                        </p>
                     </div>
                     <div className="space-y-2">
                         <Label className="text-sm font-medium">邮箱</Label>

--- a/web/src/pages/cert/features/DnsChallenge.tsx
+++ b/web/src/pages/cert/features/DnsChallenge.tsx
@@ -1,0 +1,177 @@
+import { Button } from "@/components/animate-ui/components/ui/button";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/animate-ui/components/ui/dialog";
+import { PrepareCertDns, ValidateCertDns } from "@/services/CertService";
+import { message } from "@/utils/toast";
+import { Copy, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+interface DnsChallengeProps {
+    visible: boolean;
+    item: { id: string; domain: string } | null;
+    onClose: () => void;
+    onOk: () => void;
+}
+
+interface DnsRecord {
+    recordName: string;
+    recordType: string;
+    recordValue: string;
+}
+
+async function copyText(text: string) {
+    try {
+        await navigator.clipboard.writeText(text);
+        message.success("已复制");
+    } catch {
+        message.error("复制失败");
+    }
+}
+
+export default function DnsChallengePage({
+    visible,
+    item,
+    onClose,
+    onOk,
+}: DnsChallengeProps) {
+    const [preparing, setPreparing] = useState(false);
+    const [validating, setValidating] = useState(false);
+    const [record, setRecord] = useState<DnsRecord | null>(null);
+
+    const prepare = useCallback(async () => {
+        if (!item) return;
+        setPreparing(true);
+        setRecord(null);
+        try {
+            const res = await PrepareCertDns(item.id);
+            if (res?.success === false) {
+                message.error(res.message || "获取 DNS 记录失败");
+                return;
+            }
+            setRecord(res?.data as DnsRecord);
+        } catch (err: any) {
+            message.error(err?.message || "获取 DNS 记录失败");
+        } finally {
+            setPreparing(false);
+        }
+    }, [item]);
+
+    useEffect(() => {
+        if (visible && item) {
+            setRecord(null);
+            setValidating(false);
+            prepare();
+        }
+    }, [visible, item, prepare]);
+
+    async function handleValidate() {
+        if (!item || validating) return;
+        setValidating(true);
+        try {
+            const res = await ValidateCertDns(item.id);
+            if (res?.success === false) {
+                message.error(res.message || "验证失败");
+                return;
+            }
+            message.success("证书签发成功");
+            onOk();
+        } catch (err: any) {
+            message.error(err?.message || "验证失败");
+        } finally {
+            setValidating(false);
+        }
+    }
+
+    return (
+        <Dialog open={visible} onOpenChange={(open) => !open && onClose()}>
+            <DialogContent className="max-w-lg">
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold">DNS 验证申请证书</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">域名</div>
+                        <div className="mt-1 font-medium text-foreground">{item?.domain}</div>
+                    </div>
+
+                    <p className="text-sm text-muted-foreground">
+                        请在你的域名解析服务商处添加以下 TXT 记录，等待生效后点击「验证并签发」。
+                        泛域名证书（*.example.com）仅支持此 DNS 验证方式。
+                    </p>
+
+                    {preparing ? (
+                        <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            正在获取验证记录...
+                        </div>
+                    ) : record ? (
+                        <div className="space-y-3">
+                            {[
+                                { label: "记录类型", value: record.recordType },
+                                { label: "主机记录", value: record.recordName },
+                                { label: "记录值", value: record.recordValue },
+                            ].map((row) => (
+                                <div key={row.label} className="space-y-1">
+                                    <div className="text-xs font-medium text-muted-foreground">
+                                        {row.label}
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <code className="flex-1 break-all rounded-md border bg-muted/40 px-3 py-2 text-xs">
+                                            {row.value}
+                                        </code>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-8 w-8 shrink-0"
+                                            onClick={() => copyText(row.value)}
+                                        >
+                                            <Copy className="h-4 w-4" />
+                                        </Button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="flex items-center justify-center py-6">
+                            <Button variant="outline" size="sm" onClick={prepare}>
+                                <RefreshCw className="mr-2 h-4 w-4" />
+                                重新获取记录
+                            </Button>
+                        </div>
+                    )}
+
+                    <p className="text-xs text-muted-foreground">
+                        DNS 记录生效可能需要几分钟，验证过程最长可能持续 2-3 分钟，请耐心等待。
+                        签发成功后到期需再次通过 DNS 验证续期。
+                    </p>
+                </div>
+
+                <DialogFooter className="gap-2">
+                    <Button variant="outline" onClick={onClose} className="flex-1" disabled={validating}>
+                        取消
+                    </Button>
+                    <Button
+                        onClick={handleValidate}
+                        className="flex-1"
+                        disabled={validating || preparing || !record}
+                    >
+                        {validating ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                验证中...
+                            </>
+                        ) : (
+                            "验证并签发"
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/web/src/pages/cert/features/UploadCert.tsx
+++ b/web/src/pages/cert/features/UploadCert.tsx
@@ -1,0 +1,212 @@
+import { Highlight, HighlightItem } from "@/components/animate-ui/primitives/effects/highlight";
+import { Button } from "@/components/animate-ui/components/ui/button";
+import { Input } from "@/components/animate-ui/components/ui/input";
+import { Label } from "@/components/animate-ui/components/ui/label";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/animate-ui/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { UploadCert } from "@/services/CertService";
+import { message } from "@/utils/toast";
+import { useEffect, useRef, useState } from "react";
+
+interface UploadCertProps {
+    visible: boolean;
+    onClose: () => void;
+    onOk: () => void;
+    // 传入则为“重新上传/替换”已有证书
+    editItem?: { id: string; domain: string } | null;
+}
+
+type CertType = "pfx" | "pem";
+
+export default function UploadCertPage({
+    visible,
+    onClose,
+    onOk,
+    editItem,
+}: UploadCertProps) {
+    const [domain, setDomain] = useState("");
+    const [certType, setCertType] = useState<CertType>("pfx");
+    const [password, setPassword] = useState("");
+    const [certFile, setCertFile] = useState<File | null>(null);
+    const [keyFile, setKeyFile] = useState<File | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+
+    const certInputRef = useRef<HTMLInputElement>(null);
+    const keyInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (visible) {
+            setDomain(editItem?.domain ?? "");
+            setCertType("pfx");
+            setPassword("");
+            setCertFile(null);
+            setKeyFile(null);
+            setSubmitting(false);
+            if (certInputRef.current) certInputRef.current.value = "";
+            if (keyInputRef.current) keyInputRef.current.value = "";
+        }
+    }, [visible, editItem]);
+
+    async function handleOk() {
+        if (submitting) return;
+
+        if (!domain.trim()) {
+            message.error("请输入域名");
+            return;
+        }
+        if (!certFile) {
+            message.error(certType === "pem" ? "请选择证书文件（.pem/.crt）" : "请选择证书文件（.pfx/.p12）");
+            return;
+        }
+        if (certType === "pem" && !keyFile) {
+            message.error("请选择证书私钥文件（.key）");
+            return;
+        }
+
+        const formData = new FormData();
+        if (editItem?.id) formData.append("id", editItem.id);
+        formData.append("domain", domain.trim());
+        formData.append("certType", certType);
+        formData.append("file", certFile);
+        if (certType === "pem" && keyFile) {
+            formData.append("keyFile", keyFile);
+        }
+        if (certType === "pfx") {
+            formData.append("password", password);
+        }
+
+        try {
+            setSubmitting(true);
+            const res = await UploadCert(formData);
+            if (res && res.success === false) {
+                message.error(res.message || "上传失败");
+                return;
+            }
+            message.success("上传成功");
+            onOk();
+        } catch (err: any) {
+            message.error(err?.message || "上传失败");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Dialog open={visible} onOpenChange={(open) => !open && onClose()}>
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold">
+                        {editItem ? "重新上传证书" : "上传证书"}
+                    </DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                    <div className="space-y-2">
+                        <Label className="text-sm font-medium">证书域名</Label>
+                        <Input
+                            value={domain}
+                            onChange={(e) => setDomain(e.target.value)}
+                            placeholder="请输入域名，如 example.com 或 *.example.com"
+                            className="w-full"
+                            disabled={!!editItem}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                            {editItem
+                                ? "重新上传将替换该域名现有的证书。"
+                                : "该域名将作为 SNI 匹配的主机名，请与证书中的域名保持一致，支持泛域名 *.example.com。"}
+                        </p>
+                    </div>
+
+                    <div className="space-y-2">
+                        <div className="text-sm font-medium text-foreground">证书格式</div>
+                        <Highlight
+                            controlledItems
+                            value={certType}
+                            onValueChange={(v) => setCertType((v as CertType) ?? "pfx")}
+                            className="inset-0 bg-background shadow-sm rounded-md pointer-events-none"
+                        >
+                            <div className="inline-flex h-9 w-full items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground">
+                                <HighlightItem value="pfx" className="flex-1">
+                                    <button
+                                        type="button"
+                                        className={cn(
+                                            "w-full rounded-md px-3 py-1 text-sm font-medium transition-colors",
+                                            certType === "pfx" ? "text-foreground" : "hover:text-foreground"
+                                        )}
+                                    >
+                                        PFX / P12
+                                    </button>
+                                </HighlightItem>
+                                <HighlightItem value="pem" className="flex-1">
+                                    <button
+                                        type="button"
+                                        className={cn(
+                                            "w-full rounded-md px-3 py-1 text-sm font-medium transition-colors",
+                                            certType === "pem" ? "text-foreground" : "hover:text-foreground"
+                                        )}
+                                    >
+                                        PEM / CRT
+                                    </button>
+                                </HighlightItem>
+                            </div>
+                        </Highlight>
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label className="text-sm font-medium">
+                            {certType === "pem" ? "证书文件（.pem / .crt）" : "证书文件（.pfx / .p12）"}
+                        </Label>
+                        <Input
+                            ref={certInputRef}
+                            type="file"
+                            accept={certType === "pem" ? ".pem,.crt,.cer" : ".pfx,.p12"}
+                            onChange={(e) => setCertFile(e.target.files?.[0] ?? null)}
+                            className="w-full"
+                        />
+                    </div>
+
+                    {certType === "pem" ? (
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">私钥文件（.key）</Label>
+                            <Input
+                                ref={keyInputRef}
+                                type="file"
+                                accept=".key,.pem"
+                                onChange={(e) => setKeyFile(e.target.files?.[0] ?? null)}
+                                className="w-full"
+                            />
+                        </div>
+                    ) : (
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">证书密码</Label>
+                            <Input
+                                type="password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                placeholder="若证书无密码可留空"
+                                className="w-full"
+                            />
+                        </div>
+                    )}
+
+                    <p className="text-xs text-muted-foreground">
+                        上传的证书不会参与自动续期，到期后请手动重新上传。
+                    </p>
+                </div>
+                <DialogFooter className="gap-2">
+                    <Button variant="outline" onClick={onClose} className="flex-1">
+                        取消
+                    </Button>
+                    <Button onClick={handleOk} className="flex-1" disabled={submitting}>
+                        {submitting ? "上传中..." : "确定"}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/web/src/pages/cert/page.tsx
+++ b/web/src/pages/cert/page.tsx
@@ -37,10 +37,13 @@ import {
     Search,
     Shield,
     Trash2,
+    Upload,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import CreateCertPage from "./features/CreateCert";
+import UploadCertPage from "./features/UploadCert";
+import DnsChallengePage from "./features/DnsChallenge";
 import TableList from "./features/TableList";
 
 type CertRenewStats = 0 | 1 | 2;
@@ -53,6 +56,8 @@ type CertItem = {
     renewStats: CertRenewStats;
     renewTime?: string | null;
     notAfter?: string | null;
+    // 0: Let's Encrypt 自动申请, 1: 用户上传的自定义证书
+    type?: number;
 };
 
 type RenewFilter = "all" | "none" | "success" | "failed";
@@ -100,6 +105,12 @@ function copyToClipboard(text: string) {
 
 export default function CertPage() {
     const [createVisible, setCreateVisible] = useState(false);
+    const [uploadVisible, setUploadVisible] = useState(false);
+    const [uploadItem, setUploadItem] = useState<CertItem | null>(null);
+    const [dnsDialog, setDnsDialog] = useState<{
+        open: boolean;
+        item: CertItem | null;
+    }>({ open: false, item: null });
     const [pagination, setPagination] = useState({
         page: 1,
         pageSize: 10,
@@ -243,6 +254,14 @@ export default function CertPage() {
                     return (
                         <div className="flex items-center gap-2">
                             <span className="font-medium">{item.domain || "-"}</span>
+                            {item.type === 1 ? (
+                                <Badge
+                                    variant="outline"
+                                    className="border-violet-200 bg-violet-50 font-normal text-violet-700 dark:border-violet-900/60 dark:bg-violet-950/30 dark:text-violet-300"
+                                >
+                                    自定义
+                                </Badge>
+                            ) : null}
                             {item.domain ? (
                                 <Button
                                     variant="ghost"
@@ -403,23 +422,49 @@ export default function CertPage() {
                 key: "action",
                 render: (_: unknown, item: CertItem) => {
                     const applying = Boolean(applyingIds[item.id]);
+                    const isCustom = item.type === 1;
+                    const isWildcard = (item.domain || "").includes("*");
                     return (
                         <div className="flex items-center justify-end gap-2">
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                disabled={applying || loading}
-                                onClick={() => handleApply(item)}
-                            >
-                                {applying ? (
-                                    <>
-                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                        申请中
-                                    </>
-                                ) : (
-                                    "申请证书"
-                                )}
-                            </Button>
+                            {isCustom ? (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={loading}
+                                    onClick={() => {
+                                        setUploadItem(item);
+                                        setUploadVisible(true);
+                                    }}
+                                >
+                                    <Upload className="mr-2 h-4 w-4" />
+                                    重新上传
+                                </Button>
+                            ) : isWildcard ? (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={loading}
+                                    onClick={() => setDnsDialog({ open: true, item })}
+                                >
+                                    DNS 验证
+                                </Button>
+                            ) : (
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={applying || loading}
+                                    onClick={() => handleApply(item)}
+                                >
+                                    {applying ? (
+                                        <>
+                                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                            申请中
+                                        </>
+                                    ) : (
+                                        "申请证书"
+                                    )}
+                                </Button>
+                            )}
                             <Button
                                 variant="ghost"
                                 size="sm"
@@ -465,6 +510,17 @@ export default function CertPage() {
                     >
                         <RefreshCw className="mr-2 h-4 w-4" />
                         刷新列表
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                            setUploadItem(null);
+                            setUploadVisible(true);
+                        }}
+                    >
+                        <Upload className="mr-2 h-4 w-4" />
+                        上传证书
                     </Button>
                     <Button size="sm" onClick={() => setCreateVisible(true)}>
                         <Plus className="mr-2 h-4 w-4" />
@@ -793,6 +849,26 @@ export default function CertPage() {
                 onClose={() => setCreateVisible(false)}
                 onOk={() => {
                     setCreateVisible(false);
+                    loadData();
+                }}
+            />
+
+            <UploadCertPage
+                visible={uploadVisible}
+                editItem={uploadItem}
+                onClose={() => setUploadVisible(false)}
+                onOk={() => {
+                    setUploadVisible(false);
+                    loadData();
+                }}
+            />
+
+            <DnsChallengePage
+                visible={dnsDialog.open}
+                item={dnsDialog.item}
+                onClose={() => setDnsDialog({ open: false, item: null })}
+                onOk={() => {
+                    setDnsDialog({ open: false, item: null });
                     loadData();
                 }}
             />

--- a/web/src/services/CertService.ts
+++ b/web/src/services/CertService.ts
@@ -23,3 +23,17 @@ export const UpdateCert = (id: string, value: any) => {
 export const ApplyCert = (id: string) => {
     return post(`${baseUrl}/${id}/apply`);
 }
+
+// 上传自定义证书，使用 multipart/form-data，不能手动设置 Content-Type（由浏览器附带 boundary）
+export const UploadCert = (formData: FormData) => {
+    return post(`${baseUrl}/upload`, { body: formData });
+}
+
+// 泛域名证书通过 DNS-01 验证：先获取 TXT 记录，用户添加后再校验签发
+export const PrepareCertDns = (id: string) => {
+    return post(`${baseUrl}/${id}/dns/prepare`);
+}
+
+export const ValidateCertDns = (id: string) => {
+    return post(`${baseUrl}/${id}/dns/validate`);
+}


### PR DESCRIPTION
证书管理:
- 新增上传自定义证书接口 (POST /api/v1/cert/upload)，支持 PFX/P12 与 PEM 格式， 统一转换为固定密码 pfx 落盘，校验私钥并读取有效期/颁发机构
- 新增 CertType 区分 Let's Encrypt 与用户上传证书，上传证书不参与自动续期
- 泛域名支持: SNI 按 *.example.com 匹配一级子域名，泛域名安全文件名处理， 网关缓存按泛域名失效
- 泛域名申请: 新增 DNS-01 两步验证接口 (dns/prepare、dns/validate)， 生成 _acme-challenge TXT 记录供手动添加后签发；泛域名排除出 HTTP-01 自动续期
- 前端: 新增上传证书 / 重新上传 / DNS 验证对话框及入口

修复:
- HTTPS 重定向未生效: Server.RedirectHttps 此前从未被消费，现在网关在 ACME 校验之后加入重定向中间件，将 80 端口明文请求 307 跳转到 HTTPS

文档与 CI:
- README(中/英) 补充证书管理说明与多平台下载
- release 工作流新增 linux/win/osx 的 x64 与 arm64 构建
- docker 镜像改为 linux/amd64,linux/arm64 多架构并修正触发分支

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
